### PR TITLE
feat: mine 101 blocks right away

### DIFF
--- a/docker/bitcoin-regtest/README.md
+++ b/docker/bitcoin-regtest/README.md
@@ -1,9 +1,10 @@
 # Bitcoin Regtest
 
 This app is a simple bitcoin regtest node with auto-mining enabled.
-The node will mine 1 block every 30 seconds
 
-You can disable the auto-mining by setting the `CRON_MINE_BTC` env variable to `false`
+The node will mine the 101 first blocks instantly right after initialization, so that at least one coinbase is [mature](https://bitcoin.stackexchange.com/questions/1991/what-is-the-block-maturation-time) from the get go. Then, it will automatically mine 1 new block every 30 seconds.
+
+You can disable the auto-mining by setting the `CRON_MINE_BTC` env variable to `false`. Note that it also disables the mining of the first 101 blocks.
 
 The bitcoin node rpc is listening on port `18443`, to connect to the rpc use `satoshi` as username and `satoshi` as password
 The zmq port are `28334` for raw blocks and `28335` for raw transactions
@@ -11,5 +12,5 @@ The zmq port are `28334` for raw blocks and `28335` for raw transactions
 You can use the `mine` command to mine a specific amount of blocks
 
 ```bash
-docker exec -it bitcoin-regtest mine 10
+docker exec -it bitcoin-regtest mine -b 10
 ```

--- a/docker/bitcoin-regtest/entrypoint.sh
+++ b/docker/bitcoin-regtest/entrypoint.sh
@@ -14,8 +14,9 @@ create_and_load_wallet() {
     bitcoin-cli -regtest loadwallet satoshi 2>/dev/null | true
 }
 
-# Mine blocks every 30 seconds
+# Mine 1 block every 30 seconds
 mine_btc() {
+    sleep 5 && mine -b 101
     while true; do
         sleep $MININING_INTERVAL && mine
     done


### PR DESCRIPTION
The previous configuration required to wait 100*30 seconds or manually mine 100 blocks before being able to send funds from the node's wallet.

This new version mines the first 101 blocks right away so that there is at least 1 mature coinbase to spend from as soon as users need it.